### PR TITLE
Add section for format strings

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -52,6 +52,7 @@ Guides
 * [Closures](#closures)
 * [Idiomatic Rust](#idiomatic_rust)
 * [A Guide to Reading Lifetimes](#a_guide_to_reading_lifetimes)
+* [Formatting Strings](#formatting_strings)
 * [Tooling](#tooling)
 
 Misc
@@ -641,6 +642,47 @@ Lifetimes can be overwhelming at times. Here is a simplified guide on how to rea
 |  | Any address in an `&'b X` must exist at least as long as any in an `&'a Y`. |
 
 {{ tablesep() }}
+
+</div>
+
+
+### <a name="formatting_strings"></a> Formatting Strings
+
+There are several macros that you can use to output formatted data: `print!`, `eprint!`, and `write!` (each also has a
+version with `ln`, e.g. `println!`, to print a newline). The `format!` macro can create a formatted String.
+
+<div class="cheats">
+
+Each format argument follows a basic grammar:
+
+```
+{[argument][':'[[fill]align][sign]['#']['0'][width]['.' precision][type]]}
+```
+
+Where `argument` can be omitted (next argument, counting only `{}`), a number N (the Nth zero-based argument), or an
+identifier (for named macro arguments). The full grammar for the format string and flags is [specified in the
+`std::fmt`](https://doc.rust-lang.org/std/fmt/index.html#syntax) documentation, but here are some commonly used flags:
+
+| Element | Values | Meaning |
+|---------|--------|---------|
+| `align` | `<`, `^`, `>` | Left, center, or right , if width is specified |
+| `#` | | [Alternate formatting](https://doc.rust-lang.org/std/fmt/index.html#sign0). Pretty-print with `{:#?}`, for example |
+| `0` | | Zero-pads numeric values |
+| `width` | > 0 | Minimum width, padding with `fill` (default to space) |
+| `precision` | &geq; 0 | Decimal digits for numerics, or max width for non-numerics |
+| `type` | `?`, `x`, `b`, `o` | [Debug](https://doc.rust-lang.org/std/fmt/trait.Debug.html), hex, binary, or octal ([there are more, using Traits](https://doc.rust-lang.org/std/fmt/index.html#traits)) |
+
+Note that [width](https://doc.rust-lang.org/std/fmt/index.html#width) and [precision](https://doc.rust-lang.org/std/fmt/index.html#precision) can use other arguments as their values, allowing for dynamic sizing of fields.
+
+Examples:
+
+| Example | Explanation |
+|---------|-------------|
+| `{#?}` | Pretty-print the next argument using [Debug](https://doc.rust-lang.org/std/fmt/trait.Debug.html) |
+| `{2:#?}` | Pretty-print the 3rd argument using [Debug](https://doc.rust-lang.org/std/fmt/trait.Debug.html) |
+| `{myVal:^2$}` | Center the `myVal` named argument, width specified by the 3rd argument |
+| `{:<10.3}` | Left align with width 10 and a precision of 3.|
+| `{myVal:#x}` | Format `myVal` argument as hex, with a leading `0x` (alternate format for `x`) |
 
 </div>
 


### PR DESCRIPTION
This addresses #29 by adding a new section for common format string flags
along with some examples.