### PR TITLE
Add section on rustup components

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -798,6 +798,26 @@ They often require unstable and are subject to break.
 
 </div>
 
+{{ tablesep() }}
+
+
+These are optional `rustup` components.
+Install them with `rustup component add [tool]`.
+
+<div class="cheats">
+
+
+| Tool | Description |
+|--------| ---- |
+| `clippy` | Additional lints ([list](https://rust-lang.github.io/rust-clippy/master/)) catching common API misuses and giving hints for more idiomatic code. {{ link(url = "https://github.com/rust-lang/rust-clippy") }} |
+| | Usage: `cargo clippy` |
+| `rustfmt` | Automatic code formatter. {{ link(url = "https://github.com/rust-lang/rustfmt") }} |
+| | Usage: `rustfmt <file>` or `cargo fmt [--all]` |
+
+
+</div>
+
+
 
 <!--
 


### PR DESCRIPTION
There are more (in various degrees of stability, like RLS or llvm tools)
but since clippy and rustfmt are already mentioned I chose to start with
these two.