### PR TITLE
Fix range pattern in match

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -403,7 +403,7 @@ Pattern matching arms in `match` expressions. The left side of these arms can al
 |  `_ => {}` | Proper wildcard that matches anything / "all the rest". |
 |  `[a, 0] => {}` | Match array with any value for `a` and `0` for second. |
 |  `(a, 0) => {}` | Match tuple with any value for `a` and `0` for second. |
-| `x @ 1 .. 5 => {}` | Bind matched to `x`; **pattern binding** {{ book(page="ch18-03-pattern-syntax.html#a-bindings") }} {{ ex(page="flow_control/match/binding.html#binding") }}.  |
+| `x @ 1..=5 => {}` | Bind matched to `x`; **pattern binding** {{ book(page="ch18-03-pattern-syntax.html#a-bindings") }} {{ ex(page="flow_control/match/binding.html#binding") }}.  |
 | <code>0 &vert; 1 => {}</code> | Pattern alternatives (or-patterns).|
 | {{ tab() }}  <code>E::A &vert; E::Z </code> | Same, but on enum variants. |
 | {{ tab() }}  <code>E::C {x} &vert; E::D {x}</code> | Same, but bind `x` if all variants have it. |


### PR DESCRIPTION
First of all, thank you for the incredible cheat sheet! 

I found this little issue: 
Exclusive range pattern syntax (`1..5`) is experimental. `1...5` is used in the book, but afaik it will be deprecated in favor for `1..=5`. Later works in both, stable and nightly, without a warning.