### PR TITLE
Add semicolon to the tupled struct definition

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -105,7 +105,7 @@ Data types and memory locations defined via keywords.
 |---------|-------------|
 | `struct S {}` | Define a **struct** {{ book(page="ch05-00-structs.html") }} {{ ex(page="custom_types/structs.html") }} {{ std(page="std/keyword.struct.html") }} {{ ref(page="expressions/struct-expr.html") }} with named fields. |
 | {{ tab() }} `struct S { x: T }` | Define struct with named field `x` of type `T`. |
-| {{ tab() }} `struct S` &#8203;`(T)` | Define "tupled" struct with numbered field `.0` of type `T`. |
+| {{ tab() }} `struct S` &#8203;`(T);` | Define "tupled" struct with numbered field `.0` of type `T`. |
 | {{ tab() }} `struct S;` | Define zero sized unit struct. |
 | `enum E {}` | Define an **enum** {{ book(page="ch06-01-defining-an-enum.html") }} {{ ex(page="custom_types/enum.html#enums") }} {{ ref(page="items/enumerations.html") }} , _c_. [algebraic data types](https://en.wikipedia.org/wiki/Algebraic_data_type), [tagged unions](https://en.wikipedia.org/wiki/Tagged_union). |
 | {{ tab() }}  `enum E { A, B`&#8203;`(), C {} }` | Define variants of enum; can be unit- `A`, tuple- `B` &#8203;`()` and struct-like `C{}`. |


### PR DESCRIPTION
It seems like a semicolon is missing from the tupled struct definition. As it was defined, it produced the following compiler error:

```console
error: expected one of `;` or `where`, found `fn`
  --> src/main.rs:10:1
   |
3  | struct S(T)
   |            - expected one of `;` or `where` here
```