### PR TITLE
fix a wrong usage about unsized bound

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -791,11 +791,11 @@ Basic types that can be defined by the user. The compiler might add additional p
 
 <!-- NEW ENTRY -->
 <datum class="spaced">
-    <name><code>T: !Sized</code></name>
+    <name><code>T: ?Sized</code></name>
     <visual>
        <framed class="any unsized"><code>T</code></framed>
     </visual>
-    <!-- <description><code>T : !Sized</code>, size not<br> known at compile.</description> -->
+    <!-- <description><code>T : ?Sized</code>, size not<br> known at compile.</description> -->
 </datum>
 
 


### PR DESCRIPTION
There is no "T : !Sized" kind syntax in Rust.  The correct writing is "T : ?Sized".