### PR TITLE
Add links to expression references under "Idiomatic Rust", too

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1493,7 +1493,7 @@ If you are used to programming Java or C, consider these.
 
 | Idiom | Code |
 |--------| ---- |
-| **Think in Expressions** | `x = if x { a } else { b };` |
+| **Think in Expressions** {{ ex(page="expression.html") }} {{ ref(page="expressions.html")}} | `x = if x { a } else { b };` |
 |  | `x = loop { break 5 };`  |
 |  | `fn f() -> u32 { 0 }`  |
 | **Think in Iterators** | `(1..10).map(f).collect()` |


### PR DESCRIPTION
People might stumbled on "expressions" here first, that's why i've duplicated the links from the table under `Miscellaneous`.