### PR TITLE
add section on match ergonomics to lang sugar

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -3200,6 +3200,9 @@ If something works that "shouldn't work now that you think about it", it might b
 | **Reborrow** | Since `x: &mut T` can't be copied; move new `&mut *x` instead. |
 | **Lifetime Elision** {{ book(page="ch10-03-lifetime-syntax.html#lifetime-elision") }} {{ nom(page="lifetime-elision.html#lifetime-elision") }} {{ ref(page="lifetime-elision.html#lifetime-elision") }} | Automatically annotate `f(x: &T)` to `f<'a>(x: &'a T)`.|
 | **Method Resolution** {{ ref(page="expressions/method-call-expr.html") }} | Deref or borrow `x` until `x.f()` works. |
+| **Match Ergonomics** {{ rfc(page="2005-match-ergonomics.html") }} | Repeatedly dereference [scrutinee] and add `ref` and `ref mut` to bindings. |
+
+[scrutinee]: https://doc.rust-lang.org/stable/reference/glossary.html#scrutinee
 
 </div>
 
@@ -3210,7 +3213,6 @@ If something works that "shouldn't work now that you think about it", it might b
 </magic>
 
 ---
-
 <!-- This whole section doesn't look good on print -->
 <noprint>
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -3213,6 +3213,7 @@ If something works that "shouldn't work now that you think about it", it might b
 </magic>
 
 ---
+
 <!-- This whole section doesn't look good on print -->
 <noprint>
 

--- a/templates/shortcodes/rfc.html
+++ b/templates/shortcodes/rfc.html
@@ -1,0 +1,1 @@
+<a href="https://rust-lang.github.io/rfcs/{{page}}"><sup class="expert">RFC</sup></a>


### PR DESCRIPTION
I hope you don't mind that i submitted this as an RFC instead of as an issue, so please feel free to reject but I think it we should add a section on match ergonomics to the language sugar section. I'm not 100% happy with the explanation I came up with, I feel like there might be other links we can add, and we should maybe not call it match ergonomics because the sugar here applies to all patterns, not just match patterns, but its a start!