### PR TITLE
chore: generate release on master

### DIFF
--- a/.github/workflows/generate_release.yml
+++ b/.github/workflows/generate_release.yml
@@ -22,6 +22,15 @@ jobs:
               --volume $PWD:/workspace/cheats.rs \
               --cap-add=SYS_ADMIN                \
               cheats-box ./generate_pdf.sh cheats.rs/rust_cheat_sheet.pdf
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-1
+    - name: Upload PDF to S3
+      run: |
+          aws cp cheats.rs/rust_cheat_sheet.pdf s3://cheats.rs/rust_cheat_sheet.pdf
     - uses: "marvinpinto/action-automatic-releases@latest"
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/generate_release.yml
+++ b/.github/workflows/generate_release.yml
@@ -3,7 +3,7 @@ name: generate-release
 on:
   push:
     branches:
-      - pdf-release
+      - master
 
 jobs:
   generate_release:


### PR DESCRIPTION
Hi @ralfbiedert, as you commented here #112 the activity is listed by Github notification feature and it's per user configuration, you can disable notifications for releases in this repo.

Go to https://github.com/watching and choose `Custom`, then only check `Issues` and `Pull Requests`:

![cap](https://user-images.githubusercontent.com/4080302/100670518-bf462900-333d-11eb-9ad5-0c772acb002f.png)

![cap2](https://user-images.githubusercontent.com/4080302/100670985-7478e100-333e-11eb-9dee-0615d3f37b3b.png)

Once you changed that, you can merge this PR to restore the trigger on `master` and test if everything runs as you expect.

This closes #112

Thanks for the cheat sheet, great quality and awesome resource!