### PR TITLE
Fix Tooling Section

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -7263,6 +7263,8 @@ Basic project layout, and common files and folders, as used by `cargo`. {{ below
 
 | Entry | Code |
 |--------| ---- |
+| 📁 `.cargo/` | Cargo local configurstion folder.  |
+| {{ tab() }} `config.toml` | If you want to [**customize**](https://doc.rust-lang.org/cargo/reference/config.html) visit the link. |
 | 📁 `benches/` | Benchmarks for your crate, run via **`cargo bench`**, requires nightly by default. <sup>*</sup> {{ experimental() }} |
 | 📁 `examples/` | Examples how to use your crate, they see your crate like external user would.  |
 | {{ tab() }} `my_example.rs` | Individual examples are run like **`cargo run --example my_example`**. |

--- a/content/_index.md
+++ b/content/_index.md
@@ -7267,12 +7267,12 @@ Basic project layout, and common files and folders, as used by `cargo`. {{ below
 | 📁 `examples/` | Examples how to use your crate, they see your crate like external user would.  |
 | {{ tab() }} `my_example.rs` | Individual examples are run like **`cargo run --example my_example`**. |
 | 📁 `src/` | Actual source code for your project. |
-| {{ tab() }} `build.rs` |  **Pre-build script** {{ link(url="https://doc.rust-lang.org/cargo/reference/build-scripts.html") }}, e.g., when compiling C / FFI, needs to be specified in <code class="ignore-auto language-bash">Cargo.toml</code>. |
 | {{ tab() }} `main.rs` | Default entry point for applications, this is what **`cargo run`** uses. |
 | {{ tab() }} `lib.rs` | Default entry point for libraries. This is where lookup for `my_crate::f()` starts. |
 | 📁 `tests/` | Integration tests go here, invoked via **`cargo test`**. Unit tests often stay in `src/` file. |
 | `.rustfmt.toml` | In case you want to [**customize**](https://rust-lang.github.io/rustfmt/) how **`cargo fmt`** works. |
 | `.clippy.toml` | Special configuration for certain [**clippy lints**](https://rust-lang.github.io/rust-clippy/master/index.html), utilized via **`cargo clippy`** |
+| `build.rs` |  **Pre-build script** {{ link(url="https://doc.rust-lang.org/cargo/reference/build-scripts.html") }}, e.g., when compiling C / FFI, needs to be specified in <code class="ignore-auto language-bash">Cargo.toml</code>. |
 | <code class="ignore-auto language-bash">Cargo.toml</code> | Main project configuration. Defines dependencies, artifacts ... |
 | <code class="ignore-auto language-bash">Cargo.lock</code> | Dependency details for reproducible builds, recommended to `git` for apps, not for libs. |
 </div>

--- a/content/_index.md
+++ b/content/_index.md
@@ -7369,7 +7369,7 @@ name = "my_crate"
 version = "0.1.0"
 
 [lib]
-crate_type = ["proc-macro"]
+proc-macro = true
 ```
 
 


### PR DESCRIPTION
The build file should be at the root. In addition, cargo configuration can be added locally.