### PR TITLE
added trailing separator example to Macros & Attributes section

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -537,6 +537,7 @@ Code generation constructs expanded before the actual compilation happens.
 | {{ tab() }} `$(x),?` | Same, but "zero or one time". |
 | {{ tab() }} `$(x),+` | Same, but "one or more times". |
 | {{ tab() }} `$(x)<<+` | In fact separators other than `,` are also accepted. Here: `<<`. |
+| {{ tab() }} `$(x,)+` | Separator trailing after repetition. |
 
 
 </fixed-2-column>


### PR DESCRIPTION
Interestingly, these don't appear to covered by the Rust [reference](https://doc.rust-lang.org/reference/macros-by-example.html) but they are noted in the [The Little Book of Rust Macros](https://danielkeep.github.io/tlborm/book/pat-trailing-separators.html) and they do [work](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=0cb63f7bc246e2323e1f0e6d615bf5e9).
