### PR TITLE
updated the wording of the References & Pointers intro text

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -4088,8 +4088,8 @@ These **sum types** hold a value of one of their sub types:
 
 ## References & Pointers {#references-pointers-ui}
 
-References give safe access to other memory, raw pointers `unsafe` access.
-The respective `mut` types are identical.
+References give safe access to the referent, raw pointers `unsafe` access.
+The corresponding `mut` types have an identical data layout to their immutable counterparts.
 
 
 <!-- NEW ENTRY -->


### PR DESCRIPTION
The current wording could be interpreted to mean that `mut` references and `*mut` raw pointers are "identical":

> References give safe access to other memory, raw pointers unsafe access. **The respective mut types are identical.**

I had a go at updating the wording to make it clearer.