### PR TITLE
Various fixes and suggestions

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -9535,7 +9535,7 @@ From a call site perspective that means:
 
 | Signature | Function `g` can call &hellip; |  Function `g` accepts &hellip; |
 |--------| -----------| -----------|
-| `g<F: FnOnce()>(f: F)`  | &hellip; `f()` once. |  `Fn`, `FnMut`, `FnOnce`  |
+| `g<F: FnOnce()>(f: F)`  | &hellip; `f()` only once. |  `Fn`, `FnMut`, `FnOnce`  |
 | `g<F: FnMut()>(mut f: F)`  | &hellip; `f()` multiple times. | `Fn`, `FnMut` |
 | `g<F: Fn()>(f: F)`  | &hellip; `f()` multiple times.  | `Fn` |
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -809,7 +809,7 @@ These sigils did not fit any other category but are good to know nonetheless.
 | `_` | Unnamed **wildcard** {{ ref(page="patterns.html#wildcard-pattern")}} variable binding, e.g., <code>&vert;x, _&vert; {}</code>.|
 | {{ tab() }} `let _ = x;`  | Unnamed assignment is no-op, does **not** {{ bad() }} move out `x` or preserve scope! |
 | {{ tab() }} `_ = x;`  | You can assign _anything_ to `_` without `let`, i.e.,  `_ = ignore_error();` {{ edition(ed="1.59+")}} {{ hot() }} |
-| `_x` | Variable binding explicitly marked as unused. |
+| `_x` | Will not issue _unused variable_ warnings. Variable _can_ be used though (antipattern!). |
 | `1_234_567` | Numeric separator for visual clarity. |
 | `1_u8` | Type specifier for **numeric literals** {{ ex(page="types/literals.html#literals") }} {{ ref(page="tokens.html#number-literals") }}  (also `i8`, `u16`, &hellip;). |
 | `0xBEEF`, `0o777`, `0b1001`  | Hexadecimal (`0x`), octal (`0o`) and binary (`0b`) integer literals. |

--- a/content/_index.md
+++ b/content/_index.md
@@ -554,7 +554,7 @@ Code generation constructs expanded before the actual compilation happens.
 |---------|---------|
 | `$x:ty`  | Macro capture, the `:…` **fragment** {{ ref(page="macros-by-example.html#metavariables") }} declares what is allowed for `$x`. <sup>1</sup> |
 | `$x` |  Macro substitution, e.g., use the captured `$x:ty` from above. |
-| `$(x),*` | Macro **repetition** {{ ref(page="macros-by-example.html#repetitions") }} _zero or more times_ in macros by example. |
+| `$(x),*` | Macro **repetition** {{ ref(page="macros-by-example.html#repetitions") }} _zero or more times_ in macros. |
 | {{ tab() }} `$(x),?` | Same, but _zero or one time_. |
 | {{ tab() }} `$(x),+` | Same, but _one or more times_. |
 | {{ tab() }} `$(x)<<+` | In fact separators other than `,` are also accepted. Here: `<<`. |

--- a/content/_index.md
+++ b/content/_index.md
@@ -8703,8 +8703,8 @@ struct S<T> where T: ?Sized { … }
 
 - Lifetimes act<sup>*</sup> like type parameters:
     - user must provide specific `'a` to instantiate type (compiler will help within methods),
-    - as `Vec<f32>` and `Vec<u8>` are different types, so are `S<'p>` and `S<'q>`,
-    - meaning you can't just assign value of type `S<'a>` to variable expecting `S<'b>` (exception: "subtype" relationship for lifetimes, e.g., `'a` outliving `'b`).
+    - `S<'p>` and `S<'q>` are different types, just like `Vec<f32>` and `Vec<u8>` are
+    - meaning you can't just assign value of type `S<'a>` to variable expecting `S<'b>` (exception: subtype relationship for lifetimes, i.e., `'a` outlives `'b`).
 
 
 <mini-zoo class="zoo">
@@ -8723,7 +8723,7 @@ struct S<T> where T: ?Sized { … }
 </mini-zoo>
 
 
-- `'static` is only nameable instance of the _typespace_ lifetimes.
+- `'static` is only nameable type of the lifetimes kind.
 
 ```
 // `'a is free parameter here (user can pass any specific lifetime)

--- a/content/_index.md
+++ b/content/_index.md
@@ -8723,7 +8723,7 @@ struct S<T> where T: ?Sized { … }
 </mini-zoo>
 
 
-- `'static` is only nameable type of the lifetimes kind.
+- `'static` is only globally available type of the lifetimes kind.
 
 ```
 // `'a is free parameter here (user can pass any specific lifetime)
@@ -8745,8 +8745,47 @@ let b: S;
 
 </footnotes>
 
+</description>
+</generics-section>
 
-> Note to self and TODO: that analogy seems somewhat flawed, as if `S<'a>` is to `S<'static>` like `S<T>` is to `S<u32>`, then `'static` would be a _type_; but then what's the value of that type?
+
+<!-- Section -->
+<generics-section>
+<header>Types of types: kinds</header>
+<description>
+
+Rust does not support higher-kinded types or even mention kinds, but knowing a
+bit of theory can shed some light on how generics work. Note that the following
+uses Rust-like syntax for explanations, but is not actually valid Rust.
+
+- Values have types, e.g. `true` has type `bool`, written `true: bool`.
+- Types have _kinds_, e.g. `bool` has kind `*`, also written `bool: *`. (`*` is
+  pronounced _star_ or, sometimes a bit confusingly, _type_.)
+- (Kinds have _sorts_, which is beyond scope here. Type theorits ran out of
+  English synonyms for _type_ afterwards, but luckily value/type/kind is enough
+  for most type systems anyway.)
+
+Rust conceptually uses three kinds: `*`, `kind1 -> kind2` (type constructors),
+and `lifetime`.
+
+- All values have a type of kind `*`.
+- The opposite is not true: there are types of kind `*` that have no values,
+  e.g. `!` (the empty type).
+- Type constructors such as `Vec` take a type of kind `*`, e.g. `bool`, to a
+  new type of kind `*`, in this case `Vec<bool>`. We can say `Vec: * -> *`.
+- `lifetime` is the kind of lifetimes, e.g. `'static: lifetime`. Since
+  `lifetime` is not `*`, types of kind `lifetime` cannot have values. They can
+  however be used as parameters to create types. For example in
+
+  ```rust
+  struct S<'a> {
+      x: &'a u32
+  }
+  ```
+
+  the kind of `S` is `lifetime -> *`.
+- Note that `Vec<'static>` is a kind error, because `Vec: * -> *`, not
+  `lifetime -> *`.
 
 </description>
 </generics-section>


### PR DESCRIPTION
Some active reading, some opinions. This is more of a basis for discussion rather than a please-merge-as-is.

Notes:

- I write `Vec` is the type constructor, not `Vec<>`. Reason: You would say `f: bool -> bool`, not `f(): bool -> bool`.
- I reflowed my input for easier line referencing, but that can be undone before merging.
- `fn f(x: !) {}` is called _not very useful_, [that’s not true](https://de.wikipedia.org/wiki/Ex_falso_quodlibet)!

  ```rust
  fn ex_falso<T>(x: !) -> T {
      panic!("You proved falsehood exists, the universe will now deconstruct. I hope you’re happy")
  }
  
  fn testi_mc_testface() {
      let always_ok: Result<(), !> = Ok(());
      match always_ok {
          Ok(_) => println!("ok"),
          Err(e) => ex_falso(e), // Commenting this out yields a inexhaustive match
      }
  }
  ```